### PR TITLE
Allow a custom port without a CSRF Error.

### DIFF
--- a/myproject/settings.py
+++ b/myproject/settings.py
@@ -68,6 +68,8 @@ if os.getenv("DOMAIN"):
     DOMAIN = os.getenv("DOMAIN")
     ALLOWED_HOSTS.append(DOMAIN)
     trusted_user_domain = "https://" + str(DOMAIN)
+    if os.getenv("PORT"):
+        trusted_user_domain = trusted_user_domain + ":" + str(os.getenv("PORT"))
     CSRF_TRUSTED_ORIGINS.append(trusted_user_domain)
 
 # SECURITY WARNING: don't run with debug turned on in production!


### PR DESCRIPTION
If you are using a custom port...

- If one sets `DOMAIN=vouchervault.mydomain.com`, a 403 CSRF error takes place when using a hostname as the hostname is not allowed.
- If one sets `DOMAIN=vouchervault.mydomain.com:1234`, Django returns a `Invalid HTTP_HOST header: 'vouchervault.mydomain.com:1234'. You may need to add 'vouchervault.mydomain.com:1234' to ALLOWED_HOSTS.`.

Trusted_origins should include the full https://hostname:port/ and allowed_hosts should just be 'hostname'.
[Allowed Hosts](https://docs.djangoproject.com/en/5.0/ref/settings/#allowed-hosts) is "case-insensitive, not including port", but [CSRF_TRUSTED_ORIGINS](https://docs.djangoproject.com/en/5.0/ref/settings/#csrf-trusted-origins) requires the host header to match with a port number.

Added a PORT variable that is added, if set.