### PR TITLE
feat: Support selecting camera source

### DIFF
--- a/myapp/templates/create-item.html
+++ b/myapp/templates/create-item.html
@@ -54,6 +54,10 @@
                             <div style="color: lightgray" id="outputMessage">{% trans "No QR code detected" %}.</div>
                             <div style="color: lightgray" hidden><b>Data:</b> <span id="outputData"></span></div>
                         </div>
+                        <div id="sourceSelectPanel" style="display:block">
+                            <select id="sourceSelect" style="min-width: 250px; max-width:250px">
+                            </select>
+                        </div>
                     </section>
 
                     <!-- Item Form -->

--- a/myapp/templates/edit-item.html
+++ b/myapp/templates/edit-item.html
@@ -47,6 +47,10 @@
                             <div style="color: lightgray" id="outputMessage">{% trans "No QR code detected" %}.</div>
                             <div style="color: lightgray" hidden><b>Data:</b> <span id="outputData"></span></div>
                         </div>
+                        <div id="sourceSelectPanel" style="display:block">
+                            <select id="sourceSelect" style="min-width: 250px; max-width:250px">
+                            </select>
+                        </div>
                     </section>
 
                     <!-- Item Form -->


### PR DESCRIPTION
This PR displays the available video sources to the user for selection. This should improve code scanning via camera. Especially on mobile devices, where modern smartphones often have a lot of cameras.

This supports users in selecting a proper device with focus ability.

Note: Chrome WebView browsers are still affected by a getUserMedia() permission bug. Cannot access labels and falls-back to the first device available. Often leads to the inability to scan codes properly if the first device id is a wide-angle camera with no focus support.