### PR TITLE
feat: multi domain support

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The docker container takes various environment variables:
 
 | Variable                         | Description                                                                                                     | Default                    | Optional/Mandatory  |
 |----------------------------------|-----------------------------------------------------------------------------------------------------------------|----------------------------|---------------------|
-| `DOMAIN`                         | Your Fully Qualified Domain Name (FQDN) or IP address. Used to define `ALLOWED_HOSTS` and `CSRF_TRUSTED_ORIGINS` for the Django framework. | `localhost` | Mandatory           |
+| `DOMAIN`                         | Your Fully Qualified Domain Name (FQDN) or IP address. Used to define `ALLOWED_HOSTS` and `CSRF_TRUSTED_ORIGINS` for the Django framework. May define multiple domains by comma-separating them. | `localhost` | Mandatory           |
 | `SECURE_COOKIES`                 | Set to `True` if you use a reverse proxy with TLS. Enables the `secure` cookie flag and `HSTS` HTTP response header. | `False`               | Optional            |
 | `SESSION_EXPIRE_AT_BROWSER_CLOSE`| Set to `False` if you want to keep sessions valid after browser close.                                          | `True`                     | Optional            |
 | `SESSION_COOKIE_AGE`             | Define the maximum cookie age in minutes.                                                                       | `30`                       | Optional            |

--- a/myproject/settings.py
+++ b/myproject/settings.py
@@ -42,13 +42,16 @@ DOMAIN = str(os.environ.get("DOMAIN", "localhost"))
 TRUSTED_PORT = str(os.environ.get("PORT", "8000"))
 
 if DOMAIN:
-    DOMAIN = DOMAIN.rstrip('/').replace('http://', '').replace('https://', '')
-    ALLOWED_HOSTS.append(DOMAIN)
-    TRUSTED_USER_DOMAIN_HTTP = f"http://{DOMAIN}:{TRUSTED_PORT}"
-    TRUSTED_USER_DOMAIN_HTTP_80_DEFAULT = f"http://{DOMAIN}"
-    TRUSTED_USER_DOMAIN_HTTPS = f"https://{DOMAIN}:{TRUSTED_PORT}"
-    TRUSTED_USER_DOMAIN_HTTPS_443_DEFAULT = f"https://{DOMAIN}"
-    CSRF_TRUSTED_ORIGINS.extend([TRUSTED_USER_DOMAIN_HTTP, TRUSTED_USER_DOMAIN_HTTPS, TRUSTED_USER_DOMAIN_HTTP_80_DEFAULT, TRUSTED_USER_DOMAIN_HTTPS_443_DEFAULT])
+    domains = DOMAIN.split(',')
+    for domain in domains:
+        domain = domain.strip().rstrip('/').replace('http://', '').replace('https://', '')
+        if domain:
+            ALLOWED_HOSTS.append(domain)
+            TRUSTED_USER_DOMAIN_HTTP = f"http://{domain}:{TRUSTED_PORT}"
+            TRUSTED_USER_DOMAIN_HTTP_80_DEFAULT = f"http://{domain}"
+            TRUSTED_USER_DOMAIN_HTTPS = f"https://{domain}:{TRUSTED_PORT}"
+            TRUSTED_USER_DOMAIN_HTTPS_443_DEFAULT = f"https://{domain}"
+            CSRF_TRUSTED_ORIGINS.extend([TRUSTED_USER_DOMAIN_HTTP, TRUSTED_USER_DOMAIN_HTTPS, TRUSTED_USER_DOMAIN_HTTP_80_DEFAULT, TRUSTED_USER_DOMAIN_HTTPS_443_DEFAULT])
 
 #Session Management
 CSRF_COOKIE_HTTPONLY = True


### PR DESCRIPTION
Regarding issue #55 I wanted to help you.

I had to double check how split behaves if there are no matches 😁

```python
>>> "localhost".split(",")
['localhost']
```

`strip` was added to deal with `, ` separating with a space.