### PR TITLE
Bump apprise to latest version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ django-csp==4.0
 
 # APP SPECIFIC
 qrcode==7.4.2
-apprise==1.8.0
+apprise==1.9.7
 treepoem==3.24.0
 mozilla-django-oidc==5.0.2
 


### PR DESCRIPTION
Hey there!
First of all: thanks for the great project!

I just set up my own instance and wanted to send notifications via [Resend](https://resend.com).
It didn't work because Resend support in apprise was only added in [v1.9.3](https://github.com/caronc/apprise/releases/tag/v1.9.3).

Would you mind bumping the apprise version to support Resend? 🙏 